### PR TITLE
bugfix in SelectMessageQueueByRandom

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/producer/selector/SelectMessageQueueByRandoom.java
+++ b/client/src/main/java/org/apache/rocketmq/client/producer/selector/SelectMessageQueueByRandoom.java
@@ -22,17 +22,12 @@ import org.apache.rocketmq.client.producer.MessageQueueSelector;
 import org.apache.rocketmq.common.message.Message;
 import org.apache.rocketmq.common.message.MessageQueue;
 
-public class SelectMessageQueueByRandoom implements MessageQueueSelector {
+public class SelectMessageQueueByRandom implements MessageQueueSelector {
     private Random random = new Random(System.currentTimeMillis());
 
     @Override
     public MessageQueue select(List<MessageQueue> mqs, Message msg, Object arg) {
-        int value = random.nextInt();
-        if (value < 0) {
-            value = Math.abs(value);
-        }
-
-        value = value % mqs.size();
+        int value = random.nextInt(mqs.size());
         return mqs.get(value);
     }
 }


### PR DESCRIPTION
1)`random.nextInt()` may return `Integer.MIN_VALUE`, while `Math.abs(Integer.MIN_VALUE)=Integer.MIN_VALUE`
2) fix spelling mistake.